### PR TITLE
Ensure filesync is always latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "transpile": "npx tsc -w",
-    "watch": "npx bitburner-filesync"
+    "watch": "npx bitburner-filesync@latest"
   },
   "author": "hydroflame, Hoekstraa, based on work by SlyCedix",
   "devDependencies": {


### PR DESCRIPTION
We've had people stick on old versions, unaware of bug fixes made later.
This change ensures people that are online should be running the newest version.