### PR TITLE
Fix source maps to enable ingame debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitThis": true,
     "esModuleInterop": true,
     "inlineSourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "rootDir": "src/",
     "outDir": "dist/",


### PR DESCRIPTION
The inlineSourceMap property was set to true, but due to a missing inlineSources flag, debugging the code ingame led to empty files being shown in the dev tools window.

Adding the inlineSources flag fixes this.

An argument was made that using source maps bloats the save file. This is true. However, if this is a significant issue, the inlineSourceMap flag should also be set to false. Before this fix, the file is already bloated, but ingame debugging is impossible.

To test, make a test script that includes the line `debugger;`. Enable debugging (F12) and run the script. Before this commit, it will show an empty source file. With this commit, it will show the .ts source file as expected.