### PR TITLE
Update react usage code

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Some `ns` functions, like [`ns.printRaw()`](https://github.com/bitburner-officia
 
 The game already exposes the `React` and `ReactDOM` objects globally, but in order to work with strongly typed versions in `.ts` files, you can use the included typings. To do this, use the following import:
 
-`import React, { ReactDOM } from '@react'`
+`import React from '@react'`
 
 Support for jsx is also included, so if you use the `.tsx` file ending, you can do something like:
 

--- a/src/lib/react.ts
+++ b/src/lib/react.ts
@@ -1,10 +1,4 @@
 import ReactNamespace from 'react/index';
-import ReactDomNamespace from 'react-dom';
 
-const React = window.React as typeof ReactNamespace;
-const ReactDOM = window.ReactDOM as typeof ReactDomNamespace;
-
+declare var React: typeof ReactNamespace;
 export default React;
-export {
-  ReactDOM
-}

--- a/src/template2.tsx
+++ b/src/template2.tsx
@@ -1,0 +1,16 @@
+import { NS } from "@ns";
+import React from 'lib/react';
+
+// alternate:
+// import ReactNamespace from 'react/index';
+// declare var React: typeof ReactNamespace;
+
+export async function main(ns: NS) {
+    const table = <table>
+        <tbody>
+            <tr><td>r1,c1</td><td>row1,c2</td></tr>
+            <tr><td>row1,c1</td><td>Row 2 Column 2</td></tr>
+        </tbody>
+    </table>
+    ns.tprintRaw(table);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
     "jsx": "react",
     "paths": {
       "/*": ["*"],
-      "@ns": ["../NetscriptDefinitions.d.ts"],
-      "@react": ["lib/react.ts"]
+      "@ns": ["../NetscriptDefinitions.d.ts"]
     }
   }
 }


### PR DESCRIPTION
`lib/react.ts` - Fix react script mem usage by just declaring the react global variable.

`lib/react.ts` - Remove ReactDOM import, not sure what it is needed for

`README.md` - updated sample and instructions for importing react in a script.

`tsconfig.json` - removed '@react' path mapping, this would let scripts compile but caused an error on the server when trying to run the script.